### PR TITLE
Enhancement for the Integrate() function

### DIFF
--- a/code/app/lagrange.py
+++ b/code/app/lagrange.py
@@ -59,8 +59,8 @@ def lobatto_weights(n):
     Gauss-Lobatto weights Wikipedia link-
     https://en.wikipedia.org/wiki/
     Gaussian_quadrature#Gauss.E2.80.93Lobatto_rules
-    
-    
+
+
     Examples
     --------
     lobatto_weight_function(4) returns the Gauss-Lobatto weights
@@ -322,14 +322,13 @@ def Integrate(integrand_coeffs):
         
         value_at_gauss_nodes = af.matmul(integrand, nodes_weight)
         Integral             = af.sum(value_at_gauss_nodes, 1)
-        
+ 
     if (params.scheme == 'lobatto_quadrature'):
 
         integrand       = integrand_coeffs
         lobatto_nodes   = params.lobatto_quadrature_nodes
         Lobatto_weights = params.lobatto_weights_quadrature
-        
-       
+
         nodes_tile   = af.transpose(af.tile(lobatto_nodes, 1, integrand.shape[1]))
         power        = af.flip(af.range(integrand.shape[1]))
         nodes_power  = af.broadcast(utils.power, nodes_tile, power)

--- a/code/app/params.py
+++ b/code/app/params.py
@@ -20,7 +20,7 @@ N_Elements = 10
 
 # The scheme to be used for integration. Values are either
 # 'gauss_quadrature' or 'lobatto_quadrature'
-scheme     = 'gauss_quadrature'
+scheme     = 'lobatto_quadrature'
 
 # Wave speed.
 c          = 1
@@ -34,25 +34,22 @@ c_lax      = 1
 # Array containing the LGL points in xi space.
 xi_LGL     = lagrange.LGL_points(N_LGL)
 
-# Array of the lobatto weights used during integration.
-lobatto_weights = af.np_to_af_array(lagrange.lobatto_weights(N_LGL, xi_LGL))
-
-
-# The number of Gaussian nodes for Gauss quadrature
-N_Gauss = 10
+# The number quadrature points to be used for integration.
+N_quad = 10
 
 # N_Gauss number of Gauss nodes.
-gauss_points  = lagrange.gauss_nodes(N_Gauss)
+gauss_points  = af.np_to_af_array(lagrange.gauss_nodes(N_quad))
 
 # The Gaussian weights.
-gauss_weights = af.np_to_af_array(np.zeros([N_Gauss]))
-
-for i in range(0, N_Gauss):
-    gauss_weights[i] = lagrange.gaussian_weights(N_Gauss, i)
+gauss_weights = lagrange.gaussian_weights(N_quad)
 
 
+# The lobatto nodes to be used for integration.
+lobatto_quadrature_nodes = lagrange.LGL_points(N_quad)
 
-
+# The lobatto weights to be used for integration.
+lobatto_weights_quadrature = lagrange.lobatto_weights\
+                                    (N_quad)
 
 
 # A list of the Lagrange polynomials in poly1d form.
@@ -71,8 +68,6 @@ lagrange_poly1d_list = lagrange.lagrange_polynomials(xi_LGL)[0]
 # list containing the poly1d forms of the differential of Lagrange
 # basis polynomials.
 differential_lagrange_polynomial = lagrange.differential_lagrange_poly1d()
-
-
 
 
 # Obtaining an array consisting of the LGL points mapped onto the elements.
@@ -107,13 +102,3 @@ u_init     = np.e ** (-(element_LGL) ** 2 / 0.4 ** 2)
 u          = af.constant(0, N_LGL, N_Elements, time.shape[0],\
                                  dtype = af.Dtype.f64)
 u[:, :, 0] = u_init
-
-
-
-
-
-
-
-
-
-

--- a/code/app/params.py
+++ b/code/app/params.py
@@ -13,14 +13,14 @@ from app import wave_equation
 x_nodes    = af.np_to_af_array(np.array([-1., 1.]))
 
 # The number of LGL points into which an element is split.
-N_LGL      = 8
+N_LGL      = 8 
 
 # Number of elements the domain is to be divided into.
 N_Elements = 10
 
 # The scheme to be used for integration. Values are either
 # 'gauss_quadrature' or 'lobatto_quadrature'
-scheme     = 'lobatto_quadrature'
+scheme     = 'gauss_quadrature'
 
 # Wave speed.
 c          = 1
@@ -51,23 +51,28 @@ for i in range(0, N_Gauss):
     gauss_weights[i] = lagrange.gaussian_weights(N_Gauss, i)
 
 
+
+
+
+
 # A list of the Lagrange polynomials in poly1d form.
-lagrange_poly1d_list = lagrange.lagrange_polynomials(xi_LGL)[0]
-
-# List of the product of the Lagrange basis polynomials. Used in
-# the calculation of A matrix.
-poly1d_product_list = lagrange.product_lagrange_poly(xi_LGL)
-
-# list containing the poly1d forms of the differential of Lagrange
-# basis polynomials.
-differential_lagrange_polynomial = lagrange.differential_lagrange_poly1d()
-
+lagrange_product = lagrange.product_lagrange_poly(xi_LGL)
 
 # An array containing the coefficients of the lagrange basis polynomials.
 lagrange_coeffs = af.np_to_af_array(lagrange.lagrange_polynomials(xi_LGL)[1])
 
 # Refer corresponding functions.
 lagrange_basis_value = lagrange.lagrange_function_value(lagrange_coeffs)
+
+# A list of the Lagrange polynomials in poly1d form.
+lagrange_poly1d_list = lagrange.lagrange_polynomials(xi_LGL)[0]
+
+
+# list containing the poly1d forms of the differential of Lagrange
+# basis polynomials.
+differential_lagrange_polynomial = lagrange.differential_lagrange_poly1d()
+
+
 
 
 # Obtaining an array consisting of the LGL points mapped onto the elements.
@@ -102,3 +107,13 @@ u_init     = np.e ** (-(element_LGL) ** 2 / 0.4 ** 2)
 u          = af.constant(0, N_LGL, N_Elements, time.shape[0],\
                                  dtype = af.Dtype.f64)
 u[:, :, 0] = u_init
+
+
+
+
+
+
+
+
+
+

--- a/code/app/wave_equation.py
+++ b/code/app/wave_equation.py
@@ -49,10 +49,10 @@ def mapping_xi_to_x(x_nodes, xi):
     Parameters
     ----------
     
-    x_nodes : arrayfire.Array
+    x_nodes : arrayfire.Array [2 1 1 1]
               Element nodes.
     
-    xi      : numpy.float64
+    xi      : arrayfire.Array [N 1 1 1]
               Value of :math: `\\xi`coordinate for which the corresponding
               :math: `x` coordinate is to be found.
     
@@ -72,7 +72,6 @@ def mapping_xi_to_x(x_nodes, xi):
     return x
 
 
-
 def dx_dxi_numerical(x_nodes, xi):
     '''
     Differential :math: `\\frac{dx}{d \\xi}` calculated by central
@@ -84,8 +83,8 @@ def dx_dxi_numerical(x_nodes, xi):
     x_nodes : arrayfire.Array [N_Elements 1 1 1]
               Contains the nodes of elements.
     
-    xi      : float
-              Value of :math: `\\xi`
+    xi      : arrayfire.Array [N_LGL 1 1 1]
+              Values of :math: `\\xi`
     
     Returns
     -------
@@ -105,10 +104,14 @@ def dx_dxi_analytical(x_nodes, xi):
     '''
     The analytical result for :math:`\\frac{dx}{d \\xi}` for a 1D element is
     :math: `\\frac{x_1 - x_0}{2}`
+
     Parameters
     ----------
     x_nodes : arrayfire.Array [N_Elements 1 1 1]
               Contains the nodes of elements.
+ 
+    xi      : arrayfire.Array [N_LGL 1 1 1]
+              Values of :math: `\\xi`
 
     Returns
     -------
@@ -122,34 +125,31 @@ def dx_dxi_analytical(x_nodes, xi):
     return analytical_dx_dxi
 
 
-def A_matrix(N_quad, scheme):
+def A_matrix():
     '''
     Calculates A matrix whose elements :math:`A_{p i}` are given by
     :math: `A_{p i} &= \\int^1_{-1} L_p(\\xi)L_i(\\xi) \\frac{dx}{d\\xi}`
-    These elements are to be arranged in an :math:`N \times N` array with p
-    varying from 0 to N - 1 along the rows and i along the columns.
-    The integration is carried out using Gauss-Lobatto quadrature.
+
+    The integrals are computed using the Integrate() function.
+
+    Since elements are taken to be of equal size, :math: `\\frac {dx}{dxi}
+    is same everywhere
     
-    Full description of the algorithm can be found here-
-    `https://goo.gl/Cw6tnw`
+
     Returns
     -------
     A_matrix : arrayfire.Array [N_LGL N_LGL 1 1]
                The value of integral of product of lagrange basis functions
                obtained by LGL points, using the Integrate() function
     '''
-    int_Li_Lp = lagrange.Integrate(params.lagrange_product, N_quad, scheme)
-    
-    dx_dxi = af.mean(dx_dxi_numerical((params.element_mesh_nodes[0 : 2]),\
+    int_Li_Lp = lagrange.Integrate(params.lagrange_product)
+    dx_dxi    = af.mean(dx_dxi_numerical((params.element_mesh_nodes[0 : 2]),\
                                                         params.xi_LGL))
 
     A_matrix_flat = dx_dxi * int_Li_Lp
-
-    A_matrix = af.moddims(A_matrix_flat, params.N_LGL, params.N_LGL)
+    A_matrix      = af.moddims(A_matrix_flat, params.N_LGL, params.N_LGL)
     
-
     return A_matrix
-
 
 
 def flux_x(u):
@@ -162,6 +162,7 @@ def flux_x(u):
     u : list [N_Elements]
         The analytical form of the wave equation for each element arranged in
         a list of numpy.poly1d polynomials.
+
     Returns
     -------
     flux : list [N_Elements] 
@@ -172,7 +173,8 @@ def flux_x(u):
 
     return flux
 
-def volume_integral_flux(u_n):
+
+def volume_integral_flux(u_n, N_quad = 8):
     '''
     Calculates the volume integral of flux in the wave equation.
     :math:`\\int_{-1}^1 f(u) \\frac{d L_p}{d\\xi} d\\xi`
@@ -194,14 +196,16 @@ def volume_integral_flux(u_n):
     '''
     analytical_form_flux       = flux_x(lagrange.wave_equation_lagrange(u_n))
     differential_lagrange_poly = params.differential_lagrange_polynomial
+
     integrand = np.zeros(([params.N_LGL * params.N_Elements, 2 * params.N_LGL - 2]))
 
     for i in range(params.N_LGL):
         for j in range(params.N_Elements):
-            integrand[i + params.N_LGL * j] = (analytical_form_flux[j] * differential_lagrange_poly[i]).c
+            integrand[i + params.N_LGL * j] = (analytical_form_flux[j] *\
+                                                differential_lagrange_poly[i]).c
 
-    integrand = af.np_to_af_array(integrand)
-    flux_integral = lagrange.Integrate(integrand, 9, 'lobatto_quadrature')
+    integrand     = af.np_to_af_array(integrand)
+    flux_integral = lagrange.Integrate(integrand)
     flux_integral = af.moddims(flux_integral, params.N_LGL, params.N_Elements)
 
     return flux_integral
@@ -209,8 +213,8 @@ def volume_integral_flux(u_n):
 
 def lax_friedrichs_flux(u_n):
     '''
-    A function which calculates the lax-friedrichs_flux :math:`f_i` using.
-    :math:`f_i = \\frac{F(u^{i + 1}_0) + F(u^i_{N_{LGL} - 1})}{2} - \frac
+    Calculates the lax-friedrichs_flux :math:`f_i` using.
+    :math:`f_i = \\frac{F(u^{i + 1}_0) + F(u^i_{N_{LGL} - 1})}{2} - \\frac
                 {\Delta x}{2\Delta t} (u^{i + 1}_0 - u^i_{N_{LGL} - 1})`
 
     The algorithm used is explained in the link given below
@@ -220,7 +224,12 @@ def lax_friedrichs_flux(u_n):
     ----------
     u_n : arrayfire.Array [N_LGL N_Elements 1 1]
           Amplitude of the wave at the mapped LGL nodes of each element.
-          
+    
+    Returns
+    -------
+    boundary_flux : arrayfire.Array [1 N_Elements 1 1]
+                    Contains the value of the flux at the boundary elements.
+                    Periodic boundary conditions are used.
     '''
 
     
@@ -238,8 +247,8 @@ def lax_friedrichs_flux(u_n):
 
 def surface_term(u_n):
     '''
-    A function which is used to calculate the surface term,
-    :math:`L_p (1) f_i - L_p (-1) f_{i - 1}`
+    Calculates the surface term,
+    :math:`L_p(1) f_i - L_p(-1) f_{i - 1}`
     using the lax_friedrichs_flux function and lagrange_basis_value
     from params module.
     
@@ -263,7 +272,6 @@ def surface_term(u_n):
     
     `https://goo.gl/Nhhgzx`
     '''
-
     L_p_minus1   = params.lagrange_basis_value[:, 0]
     L_p_1        = params.lagrange_basis_value[:, -1]
     f_i          = lax_friedrichs_flux(u_n)
@@ -304,13 +312,13 @@ def b_vector(u_n):
 
 def time_evolution():
     '''
-    Function which solves the wave equation
+    Solves the wave equation
     :math: `u^{t_n + 1} = b(t_n) \\times A`
     iterated over time steps t_n and then plots :math: `x` against the amplitude
     of the wave. The images are then stored in Wave folder.
     '''
     
-    A_inverse   = af.inverse(A_matrix(9, 'gauss_quadrature'))
+    A_inverse   = af.inverse(A_matrix())
     element_LGL = params.element_LGL
     delta_t     = params.delta_t
     amplitude   = params.u 
@@ -318,8 +326,9 @@ def time_evolution():
     
     for t_n in trange(0, time.shape[0] - 1):
         
-        amplitude[:, :, t_n + 1] = amplitude[:, :, t_n] + af.blas.matmul(A_inverse,\
-                b_vector(amplitude[:, :, t_n]))
+        amplitude[:, :, t_n + 1] =   amplitude[:, :, t_n]\
+                                   + af.blas.matmul(A_inverse,\
+                                     b_vector(amplitude[:, :, t_n]))
     
     print('u calculated!')
     

--- a/code/main.py
+++ b/code/main.py
@@ -3,6 +3,7 @@
 import arrayfire as af
 import numpy as np
 af.set_backend('opencl')
+from matplotlib import pyplot as plt
 
 from app import params
 from unit_test import test_waveEqn

--- a/code/main.py
+++ b/code/main.py
@@ -9,8 +9,5 @@ from unit_test import test_waveEqn
 from app import wave_equation
 from app import lagrange
 
-
 if __name__ == '__main__':
-    #print(lagrange.product_lagrange_poly(params.xi_LGL))
     wave_equation.time_evolution()
-    print(params.lagrange_basis_value)

--- a/code/unit_test/test_waveEqn.py
+++ b/code/unit_test/test_waveEqn.py
@@ -14,6 +14,56 @@ from utils import utils
 
 # This test uses the initial paramters N_LGL = 8, N_Elements = 10 and c = 1.
 
+
+def test_LGL_points():
+    '''
+    Comparing the LGL nodes obtained by LGL_points with
+    the reference nodes for N = 6
+    '''
+    reference_nodes  = \
+        af.np_to_af_array(np.array([-1.,                 -0.7650553239294647,\
+                                    -0.28523151648064504, 0.28523151648064504,\
+                                     0.7650553239294647,  1. \
+                                   ] \
+                                  ) \
+                         )
+        
+    calculated_nodes = (lagrange.LGL_points(6))
+    assert(af.max(af.abs(reference_nodes - calculated_nodes)) <= 1e-14)
+
+
+def test_gauss_nodes():
+    '''
+    The Gauss points obtained by the function above is compared to
+    analytical values.
+    Reference
+    ---------
+    `https://goo.gl/9gqLpe` 
+    '''
+    threshold = 1e-10
+    analytical_gauss_nodes = np.array([-0.906179845938664, -0.5384693101056831,\
+                                        0, 0.5384693101056831, 0.906179845938664])
+    calculated_gauss_nodes = lagrange.gauss_nodes(5)
+    
+    assert np.max(abs(analytical_gauss_nodes - calculated_gauss_nodes)) <= threshold
+
+
+def test_gauss_weights():
+    '''
+    Test to check the gaussian weights calculated.
+    '''
+    threshold = 2e-8
+    analytical_gauss_weights = af.Array([0.23692688505618908, 0.47862867049936647,\
+                                         0.5688888888888889, 0.47862867049936647, \
+                                         0.23692688505618908
+                                        ]
+                                       )
+    calculated_gauss_weights = lagrange.gaussian_weights(5)
+
+    assert af.max(af.abs(analytical_gauss_weights - calculated_gauss_weights))\
+                                                                  <= threshold
+
+
 def test_mapping_xi_to_x():
     '''
     A test function to check the mapping_xi_to_x function in wave_equation module,
@@ -146,7 +196,8 @@ def test_lagrange_coeffs():
                 
     basis_array_analytical = af.interop.np_to_af_array(basis_array_analytical)
     
-    assert af.sum(af.abs(basis_array_analytical - params.lagrange_coeffs)) < threshold
+    assert af.sum(af.abs(basis_array_analytical - params.lagrange_coeffs))\
+                                                               < threshold
 
 def test_A_matrix():
     '''
@@ -156,6 +207,7 @@ def test_A_matrix():
     threshold = 1e-8
     
     reference_A_matrix = 0.1 * af.interop.np_to_af_array(np.array([\
+
     [0.03333333333332194, 0.005783175201965206, -0.007358427761753982, \
     0.008091331778355441, -0.008091331778233877, 0.007358427761705623, \
     -0.00578317520224949, 0.002380952380963754], \
@@ -187,6 +239,7 @@ def test_A_matrix():
     [0.002380952380963754, -0.005783175202249493, 0.007358427761705624, \
     -0.008091331778233875, 0.008091331778355443, -0.0073584277617539835, \
     0.0057831752019652065, 0.033333333333321946]
+
     ]))
     
     test_A_matrix = wave_equation.A_matrix()
@@ -296,7 +349,8 @@ def test_b_vector():
     threshold = 1e-13
     params.c = 1
     
-    u_n_A_matrix         = af.blas.matmul(wave_equation.A_matrix(), params.u[:, :, 0])
+    u_n_A_matrix         = af.blas.matmul(wave_equation.A_matrix(),\
+                                                  params.u[:, :, 0])
     volume_integral_flux = wave_equation.volume_integral_flux(params.u[:, :, 0])
     surface_term         = test_surface_term()
     b_vector_analytical  = u_n_A_matrix + (volume_integral_flux -\
@@ -305,47 +359,16 @@ def test_b_vector():
     
     assert (b_vector_analytical - b_vector_array) < threshold
 
-
-
-def test_gauss_nodes():
-    '''
-    The Gauss points obtained by the function above is compared to
-    analytical values.
-    Reference
-    ---------
-    `https://goo.gl/9gqLpe` 
-    '''
-    threshold = 1e-10
-    analytical_gauss_nodes = np.array([-0.906179845938664, -0.5384693101056831,\
-                                        0, 0.5384693101056831, 0.906179845938664])
-    calculated_gauss_nodes = lagrange.gauss_nodes(5)
-    
-    assert np.max(abs(analytical_gauss_nodes - calculated_gauss_nodes)) <= threshold
-
-def test_gauss_weights():
-    '''
-    Test to check the gaussian weights calculated.
-    '''
-    threshold = 2e-8
-    analytical_gauss_weights = af.Array([0.23692688505618908, 0.47862867049936647,\
-                                         0.5688888888888889, 0.47862867049936647, \
-                                         0.23692688505618908
-                                        ]
-                                       )
-    calculated_gauss_weights = lagrange.gaussian_weights(5)
-
-    assert af.max(af.abs(analytical_gauss_weights - calculated_gauss_weights)) <= threshold
-
-
 def test_Integrate():
     '''
-    Testing the Integrate() function by passing coefficients of a polynomial and comparing
-    it to the analytical result.
+    Testing the Integrate() function by passing coefficients 
+    of a polynomial and comparing it to the analytical result.
     '''
     threshold = 1e-14
 
     test_coeffs = af.np_to_af_array(np.array([7., 6, 4, 2, 1, 3, 9, 2]))
-    # The coefficients of a test polynomial `7x^7 + 6x^6 + 4x^5 + 2x^4 + x^3 + 3x^2 + 9x + 2`
+    # The coefficients of a test polynomial 
+    # `7x^7 + 6x^6 + 4x^5 + 2x^4 + x^3 + 3x^2 + 9x + 2`
 
     # Using Integrate() function.
 
@@ -354,4 +377,3 @@ def test_Integrate():
     analytical_integral = 8.514285714285714
 
     assert (calculated_integral - analytical_integral) <= threshold
-    

--- a/code/unit_test/test_waveEqn.py
+++ b/code/unit_test/test_waveEqn.py
@@ -189,7 +189,7 @@ def test_A_matrix():
     0.0057831752019652065, 0.033333333333321946]
     ]))
     
-    test_A_matrix = wave_equation.A_matrix()
+    test_A_matrix = wave_equation.A_matrix(9, 'gauss_quadrature')
     print(test_A_matrix.shape, reference_A_matrix.shape)
     error_array = af.abs(reference_A_matrix - test_A_matrix)
     
@@ -285,7 +285,7 @@ def test_b_vector():
     threshold = 1e-13
     params.c = 1
     
-    u_n_A_matrix         = af.blas.matmul(wave_equation.A_matrix(), params.u[:, :, 0])
+    u_n_A_matrix         = af.blas.matmul(wave_equation.A_matrix(9, 'gauss_quadrature'), params.u[:, :, 0])
     volume_integral_flux = wave_equation.volume_integral_flux(params.u[:, :, 0])
     surface_term         = test_surface_term()
     b_vector_analytical  = u_n_A_matrix + (volume_integral_flux -\

--- a/code/unit_test/test_waveEqn.py
+++ b/code/unit_test/test_waveEqn.py
@@ -189,7 +189,7 @@ def test_A_matrix():
     0.0057831752019652065, 0.033333333333321946]
     ]))
     
-    test_A_matrix = wave_equation.A_matrix(9, 'gauss_quadrature')
+    test_A_matrix = wave_equation.A_matrix()
     print(test_A_matrix.shape, reference_A_matrix.shape)
     error_array = af.abs(reference_A_matrix - test_A_matrix)
     
@@ -209,29 +209,40 @@ def test_volume_integral_flux():
     threshold = 8e-9
     params.c = 1
     
-    referenceFluxIntegral = af.transpose(af.interop.np_to_af_array(np.array([
+    referenceFluxIntegral = af.transpose(af.interop.np_to_af_array(np.array
+        ([
         [-0.002016634876668093, -0.000588597708116113, -0.0013016773719126333,\
         -0.002368387579324652, -0.003620502047659841, -0.004320197094090966,
         -0.003445512010153811, 0.0176615086879261],\
+
         [-0.018969769374, -0.00431252844519,-0.00882630935977,-0.0144355176966,\
         -0.019612124119, -0.0209837936827, -0.0154359890788, 0.102576031756], \
+
         [-0.108222418798, -0.0179274222595, -0.0337807018822, -0.0492589052599,\
         -0.0588472807471, -0.0557970236273, -0.0374764132459, 0.361310165819],\
+
         [-0.374448714304, -0.0399576371245, -0.0683852285846, -0.0869229749357,\
         -0.0884322503841, -0.0714664112839, -0.0422339853622, 0.771847201979], \
+
         [-0.785754362849, -0.0396035640187, -0.0579313769517, -0.0569022801117,\
         -0.0392041960688, -0.0172295769141, -0.00337464521455, 1.00000000213],\
+
         [-1.00000000213, 0.00337464521455, 0.0172295769141, 0.0392041960688,\
         0.0569022801117, 0.0579313769517, 0.0396035640187, 0.785754362849],\
+
         [-0.771847201979, 0.0422339853622, 0.0714664112839, 0.0884322503841, \
         0.0869229749357, 0.0683852285846, 0.0399576371245, 0.374448714304],\
+
         [-0.361310165819, 0.0374764132459, 0.0557970236273, 0.0588472807471,\
         0.0492589052599, 0.0337807018822, 0.0179274222595, 0.108222418798], \
+
         [-0.102576031756, 0.0154359890788, 0.0209837936827, 0.019612124119, \
         0.0144355176966, 0.00882630935977, 0.00431252844519, 0.018969769374],\
+
         [-0.0176615086879, 0.00344551201015 ,0.00432019709409, 0.00362050204766,\
-        0.00236838757932, 0.00130167737191, 0.000588597708116, 0.00201663487667\
-            ]])))
+        0.00236838757932, 0.00130167737191, 0.000588597708116, 0.00201663487667]\
+
+         ])))
     
     numerical_flux = wave_equation.volume_integral_flux(params.u[:, :, 0])
     assert (af.max(af.abs(numerical_flux - referenceFluxIntegral)) < threshold)
@@ -285,7 +296,7 @@ def test_b_vector():
     threshold = 1e-13
     params.c = 1
     
-    u_n_A_matrix         = af.blas.matmul(wave_equation.A_matrix(9, 'gauss_quadrature'), params.u[:, :, 0])
+    u_n_A_matrix         = af.blas.matmul(wave_equation.A_matrix(), params.u[:, :, 0])
     volume_integral_flux = wave_equation.volume_integral_flux(params.u[:, :, 0])
     surface_term         = test_surface_term()
     b_vector_analytical  = u_n_A_matrix + (volume_integral_flux -\
@@ -293,3 +304,54 @@ def test_b_vector():
     b_vector_array       = wave_equation.b_vector(params.u[:, :, 0])
     
     assert (b_vector_analytical - b_vector_array) < threshold
+
+
+
+def test_gauss_nodes():
+    '''
+    The Gauss points obtained by the function above is compared to
+    analytical values.
+    Reference
+    ---------
+    `https://goo.gl/9gqLpe` 
+    '''
+    threshold = 1e-10
+    analytical_gauss_nodes = np.array([-0.906179845938664, -0.5384693101056831,\
+                                        0, 0.5384693101056831, 0.906179845938664])
+    calculated_gauss_nodes = lagrange.gauss_nodes(5)
+    
+    assert np.max(abs(analytical_gauss_nodes - calculated_gauss_nodes)) <= threshold
+
+def test_gauss_weights():
+    '''
+    Test to check the gaussian weights calculated.
+    '''
+    threshold = 2e-8
+    analytical_gauss_weights = af.Array([0.23692688505618908, 0.47862867049936647,\
+                                         0.5688888888888889, 0.47862867049936647, \
+                                         0.23692688505618908
+                                        ]
+                                       )
+    calculated_gauss_weights = lagrange.gaussian_weights(5)
+
+    assert af.max(af.abs(analytical_gauss_weights - calculated_gauss_weights)) <= threshold
+
+
+def test_Integrate():
+    '''
+    Testing the Integrate() function by passing coefficients of a polynomial and comparing
+    it to the analytical result.
+    '''
+    threshold = 1e-14
+
+    test_coeffs = af.np_to_af_array(np.array([7., 6, 4, 2, 1, 3, 9, 2]))
+    # The coefficients of a test polynomial `7x^7 + 6x^6 + 4x^5 + 2x^4 + x^3 + 3x^2 + 9x + 2`
+
+    # Using Integrate() function.
+
+    calculated_integral = lagrange.Integrate(af.transpose(test_coeffs))
+
+    analytical_integral = 8.514285714285714
+
+    assert (calculated_integral - analytical_integral) <= threshold
+    

--- a/code/utils/utils.py
+++ b/code/utils/utils.py
@@ -77,6 +77,32 @@ def multiply(a, b):
     
     return product
 
+def power(a, b):
+    '''
+       
+    For broadcasting purposes, To divide two arrays of different
+    shapes, A function which can sum two variables is required.
+    
+    Parameters
+    ----------
+    a : arrayfire.Array [N M 1 1]
+        One of the arrays which need to be broadcasted and multiplying.
+    
+    b : arrayfire.Array [1 M L 1]
+        One of the arrays which need to be broadcasted and multiplying.
+    
+    Returns
+    -------
+    product : arrayfire.Array
+              returns the quotient a / b. When used along with af.broadcast
+              can be used to give quotient of two different size arrays
+              by multiplying elements of the broadcasted array.
+    '''
+    pow = a ** b
+    
+    return pow
+
+
 
 def linspace(start, end, number_of_points):
     '''


### PR DESCRIPTION
In the previous PR #16 , To compute the integrals in the code an Integrate() function which takes in the analytical form of the function to compute the integral using quadrature method was implemented.

Integrations in the code were not vectorized and hence the code was slow(1.1 iterations/second on Inspiron-3542).

This PR uses an Integrate function which takes in the coefficients of the integrands and returns the integral. This implementation is vectorized and is faster (40 iterations/second).

The 1D wave equation bug #6  is still present, however it's nature hasn't been confirmed.
