### PR TITLE
Travis cmake bugfix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,13 @@ python:
 
 # command to install dependencies
 before_install:
-    - ls -al
-    - pwd
     - cd ..
-    - ls -al
     - sudo apt-get update -qq
-    - sudo apt-get install -qq build-essential git cmake libfreeimage-dev cmake-curses-gui
+    - sudo apt-get install -qq build-essential git cmake3 libfreeimage-dev cmake3-curses-gui
     - sudo apt-get install -qq libopenblas-dev libfftw3-dev liblapacke-dev libboost-all-dev
     - sudo apt-get install -qq libfontconfig1-dev
-    - sudo apt-get install build-essential cmake cmake-curses-gui xorg-dev libglu1-mesa-dev libxinerama-dev libxcursor-dev
+    - sudo apt-get install build-essential xorg-dev libglu1-mesa-dev libxinerama-dev libxcursor-dev
     - grep MemTotal /proc/meminfo
-    - cat /proc/cpuinfo
     - wget https://github.com/glfw/glfw/archive/3.1.2.zip -O glfw-3.1.2.zip
     - unzip glfw-3.1.2.zip
     - cd glfw-3.1.2
@@ -41,21 +37,15 @@ before_install:
     - export AF_PATH=$PWD
     - cd lib
     - export LD_LIBRARY_PATH=$PWD:$LD_LIBRARY_PATH
-    - echo $LD_LIBRARY_PATH
     - cd ../../../../
     - cd arrayfire/build
-#    - make test
     - cd ../../
     - git clone https://github.com/amanabt/gmshtranslator.git
     - cd gmshtranslator
     - sudo pip install -e .
     - cd ..
     - pip install virtualenv
-    - pwd
-    - ls -al
     - cd DG_Maxwell
-    - pwd
-    - ls -al
     - virtualenv venv 
     - source venv/bin/activate
 


### PR DESCRIPTION
**Commit:** 38d4d64d78ea6ecc8ee46c174311d3912e0e99fc

**Issue:** Travis build was failing because Travis OS, Trusty Tahr, was installing cmake3.2 whereas CMake required version was \> 3.5.

**Description**
**Bug:** Travis runs the build on Ubuntu Trusty Tahr which by default, installs cmake3.2. The build was failing because arrayfire package required CMake version > 3.5.

**Proposed changes:**
- CMake 3.5 and related packages are now being installed with the command
```bash
$ sudo apt-get install cmake3 cmake3-curses-gui
```
- Minor cleanup like removing `echo`, `ls`, and `pwd` commands from `.travis.yml`